### PR TITLE
星評価レイアウト修正

### DIFF
--- a/src/public/css/reviewAll.css
+++ b/src/public/css/reviewAll.css
@@ -134,20 +134,30 @@
     color: #0051FF;
     height: 25px;
     font-size: 15px;
+    z-index: 1;
+}
+
+.star_rating-back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    white-space: nowrap;
+    color: #C0C0C0;
+    height: 25px;
+    font-size: 15px;
+    z-index: 0;
 }
 
 @media screen and (max-width: 768px) {
-    .star_rating-front {
+    .star_rating-front,
+    .star_rating-back {
         font-size: 10px;
     }
 }
 
 @media screen and (max-width: 480px) {
-    .star_rating-front {
+    .star_rating-front,
+    .star_rating-back {
         font-size: 10px;
     }
-}
-
-.star_rating-back {
-    color: #C0C0C0;
 }


### PR DESCRIPTION
## 変更目的
星評価のレイアウト崩れを修正するため

## 影響範囲
reviewAll.css

## 再現手順
1. 未評価の星（.star_rating-back）に以下のスタイルを追加
.star_rating-back {
    position: absolute;
    top: 0;
    left: 0;
    white-space: nowrap;
    color: #C0C0C0;
    height: 25px;
    font-size: 15px;
    z-index: 0;
}

2. 評価ずみの星（.star_rating-front）には、最前に表示されるように、z-index: 0; を追加
3. スマホでのレイアウト崩れを修正するために、@media screen のスタイルにも.star_rating-backを追加

## 動作確認
ディベロッパーツールにて、各端末サイズでのレイアウトの崩れがないか確認


